### PR TITLE
Added full cell type names on hover

### DIFF
--- a/src/browsers/tob/components/TOBAggregatePlot.js
+++ b/src/browsers/tob/components/TOBAggregatePlot.js
@@ -10,7 +10,16 @@ import DotplotHeatmap from '../shared/components/DotplotHeatmap'
 import StatusMessage from '../shared/components/StatusMessage'
 import AggregateTooltip from '../shared/components/AggregateTooltip'
 
-const TOBAggregatePlot = ({ query, selected, onClick, onRowClick, width, height, margin }) => {
+const TOBAggregatePlot = ({
+  query,
+  selected,
+  onClick,
+  onRowClick,
+  width,
+  height,
+  margin,
+  cellTypes,
+}) => {
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState(null)
   const [response, setResponse] = useState(null)
@@ -59,8 +68,9 @@ const TOBAggregatePlot = ({ query, selected, onClick, onRowClick, width, height,
         if (response) return d.gene_id === sortBy(response, ['gene_id'])[0]?.gene_id
         return false
       },
+      tickHelp: (d) => cellTypes?.find((x) => x.cell_type_id === d).cell_type_name,
     }
-  }, [selected, response])
+  }, [selected, response, cellTypes])
 
   if (error) {
     return (
@@ -105,6 +115,13 @@ TOBAggregatePlot.propTypes = {
   margin: appPropTypes.margin,
   onClick: PropTypes.func,
   onRowClick: PropTypes.func,
+  cellTypes: PropTypes.arrayOf(
+    PropTypes.shape({
+      cell_type_id: PropTypes.string,
+      cell_type_name: PropTypes.string,
+      description: PropTypes.string,
+    })
+  ),
 }
 
 TOBAggregatePlot.defaultProps = {
@@ -114,6 +131,7 @@ TOBAggregatePlot.defaultProps = {
   width: null,
   height: null,
   margin: { top: 20, right: 210, bottom: 0, left: 100 },
+  cellTypes: null,
 }
 
 export default TOBAggregatePlot

--- a/src/browsers/tob/components/TOBAggregatePlot.js
+++ b/src/browsers/tob/components/TOBAggregatePlot.js
@@ -68,7 +68,7 @@ const TOBAggregatePlot = ({
         if (response) return d.gene_id === sortBy(response, ['gene_id'])[0]?.gene_id
         return false
       },
-      tickHelp: (d) => cellTypes?.find((x) => x.cell_type_id === d).cell_type_name,
+      xTickHelp: (d) => cellTypes?.find((x) => x.cell_type_id === d).cell_type_name,
     }
   }, [selected, response, cellTypes])
 

--- a/src/browsers/tob/components/TOBViolinPlotNew.js
+++ b/src/browsers/tob/components/TOBViolinPlotNew.js
@@ -38,7 +38,7 @@ const TOBViolinPlot = ({ query, margin, height, yLabel, fontSize, cellTypes }) =
         return CELL_COLORS[key]
       },
       tooltip: (d) => <BoxplotTooltip statistics={d} />,
-      tickHelp: (d) => cellTypes?.find((x) => x.cell_type_id === d).cell_type_name,
+      xTickHelp: (d) => cellTypes?.find((x) => x.cell_type_id === d).cell_type_name,
     }
   }, [query, cellTypes])
 

--- a/src/browsers/tob/components/TOBViolinPlotNew.js
+++ b/src/browsers/tob/components/TOBViolinPlotNew.js
@@ -13,7 +13,7 @@ import LoadingOverlay from '../shared/components/LoadingOverlay'
 
 const CELL_COLORS = defaultCellTypeColors()
 
-const TOBViolinPlot = ({ query, margin, height, yLabel, fontSize }) => {
+const TOBViolinPlot = ({ query, margin, height, yLabel, fontSize, cellTypes }) => {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState(null)
   const [data, setData] = useState(null)
@@ -38,8 +38,9 @@ const TOBViolinPlot = ({ query, margin, height, yLabel, fontSize }) => {
         return CELL_COLORS[key]
       },
       tooltip: (d) => <BoxplotTooltip statistics={d} />,
+      tickHelp: (d) => cellTypes?.find((x) => x.cell_type_id === d).cell_type_name,
     }
-  }, [query])
+  }, [query, cellTypes])
 
   useEffect(() => {
     if (!query) return
@@ -128,6 +129,7 @@ const TOBViolinPlot = ({ query, margin, height, yLabel, fontSize }) => {
           margin={margin}
           accessors={accessors}
           fontSize={fontSize}
+          cellTypes={cellTypes}
         />
       </LoadingOverlay>
     </div>
@@ -145,6 +147,13 @@ TOBViolinPlot.propTypes = {
   }),
   yLabel: PropTypes.string,
   fontSize: PropTypes.number,
+  cellTypes: PropTypes.arrayOf(
+    PropTypes.shape({
+      cell_type_id: PropTypes.string,
+      cell_type_name: PropTypes.string,
+      description: PropTypes.string,
+    })
+  ),
 }
 
 TOBViolinPlot.defaultProps = {
@@ -152,6 +161,7 @@ TOBViolinPlot.defaultProps = {
   margin: {},
   yLabel: 'log(CPM)',
   fontSize: 14,
+  cellTypes: null,
 }
 
 export default TOBViolinPlot

--- a/src/browsers/tob/pages/TOBGenePage.js
+++ b/src/browsers/tob/pages/TOBGenePage.js
@@ -221,8 +221,8 @@ const TOBGenePage = () => {
         return cellTypeSelection[c.cell_type_id] && !excludedColumns.includes(c.cell_type_id)
           ? {
               key: c.cell_type_id,
-              help: c.cell_type_id,
-              content: c.cell_type_name,
+              help: c.cell_type_name,
+              content: c.cell_type_id,
             }
           : null
       }),
@@ -281,7 +281,12 @@ const TOBGenePage = () => {
 
         <section>
           <SectionHeading>Cell type expression</SectionHeading>
-          <TOBViolinPlot query={query.gene} height={500} margin={{ left: 100, bottom: 75 }} />
+          <TOBViolinPlot
+            query={query.gene}
+            height={500}
+            margin={{ left: 100, bottom: 75 }}
+            cellTypes={cellTypes}
+          />
         </section>
 
         <section>
@@ -297,6 +302,7 @@ const TOBGenePage = () => {
             margin={{ top: 20, right: 250, bottom: 125, left: 100 }}
             onClick={onSelectAggregate}
             onRowClick={onSelectAggregate}
+            cellTypes={cellTypes}
           />
         </section>
 

--- a/src/browsers/tob/pages/TOBVariantPage.js
+++ b/src/browsers/tob/pages/TOBVariantPage.js
@@ -223,8 +223,8 @@ const TOBVariantPage = () => {
         return cellTypeSelection[c.cell_type_id] && !excludedColumns.includes(c.cell_type_id)
           ? {
               key: c.cell_type_id,
-              help: c.cell_type_id,
-              content: c.cell_type_name,
+              help: c.cell_type_name,
+              content: c.cell_type_id,
             }
           : null
       }),
@@ -291,6 +291,7 @@ const TOBVariantPage = () => {
             margin={{ top: 20, right: 250, bottom: 125, left: 100 }}
             onClick={onSelectAggregate}
             onRowClick={onSelectAggregate}
+            cellTypes={cellTypes}
           />
         </section>
 

--- a/src/browsers/tob/shared/components/DotplotHeatmap.js
+++ b/src/browsers/tob/shared/components/DotplotHeatmap.js
@@ -16,7 +16,7 @@ const DEFAULT_ACCESSORS = {
   color: (d) => d.color,
   tooltip: (d) => d.tooltip,
   isSelected: (d) => d.selected,
-  tickHelp: (d) => d.tickHelp,
+  xTickHelp: (d) => d.xTickHelp,
 }
 
 const DotplotHeatmap = ({
@@ -168,7 +168,7 @@ const DotplotHeatmap = ({
                 cursor="help"
               >
                 {tick}
-                <title>{_accessors.tickHelp(tick)}</title>
+                <title>{_accessors.xTickHelp(tick)}</title>
               </text>
               <line y2={6} stroke="black" />
               <line y2={`-${innerHeight}`} stroke="lightgrey" />

--- a/src/browsers/tob/shared/components/DotplotHeatmap.js
+++ b/src/browsers/tob/shared/components/DotplotHeatmap.js
@@ -16,6 +16,7 @@ const DEFAULT_ACCESSORS = {
   color: (d) => d.color,
   tooltip: (d) => d.tooltip,
   isSelected: (d) => d.selected,
+  tickHelp: (d) => d.tickHelp,
 }
 
 const DotplotHeatmap = ({
@@ -164,8 +165,10 @@ const DotplotHeatmap = ({
                 textAnchor="end"
                 alignmentBaseline="middle"
                 fontSize={14}
+                cursor="help"
               >
                 {tick}
+                <title>{_accessors.tickHelp(tick)}</title>
               </text>
               <line y2={6} stroke="black" />
               <line y2={`-${innerHeight}`} stroke="lightgrey" />

--- a/src/browsers/tob/shared/components/ViolinPlotNew.js
+++ b/src/browsers/tob/shared/components/ViolinPlotNew.js
@@ -18,6 +18,7 @@ const DEFAULT_ACCESSORS = {
   min: (d) => d.min,
   max: (d) => d.max,
   color: (d) => d.color,
+  tickHelp: (d) => d.tickHelp,
 }
 
 const ViolinPlot = ({
@@ -152,8 +153,10 @@ const ViolinPlot = ({
                   textAnchor="end"
                   alignmentBaseline="middle"
                   fontSize={fontSize}
+                  cursor="help"
                 >
                   {tick}
+                  <title>{_accessors.tickHelp(tick)}</title>
                 </text>
                 <line y2={6} stroke="black" />
               </g>

--- a/src/browsers/tob/shared/components/ViolinPlotNew.js
+++ b/src/browsers/tob/shared/components/ViolinPlotNew.js
@@ -18,7 +18,7 @@ const DEFAULT_ACCESSORS = {
   min: (d) => d.min,
   max: (d) => d.max,
   color: (d) => d.color,
-  tickHelp: (d) => d.tickHelp,
+  xTickHelp: (d) => d.xTickHelp,
 }
 
 const ViolinPlot = ({
@@ -156,7 +156,7 @@ const ViolinPlot = ({
                   cursor="help"
                 >
                   {tick}
-                  <title>{_accessors.tickHelp(tick)}</title>
+                  <title>{_accessors.xTickHelp(tick)}</title>
                 </text>
                 <line y2={6} stroke="black" />
               </g>


### PR DESCRIPTION
Added full cell type names on hover for dotplotheatmap and violinplot x axis ticks
Swapped effect grid column names to cell id and tooltip to full cell name
Changed hover cursor to 'help' question mark cursor
 